### PR TITLE
fix(cors): allow Cinny via dynamic origin allowlist

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -85,6 +85,25 @@ if grep -q "matrix.inblock.io" "$CADDYFILE"; then
 else
   cat >> "$CADDYFILE" << 'EOF'
 
+# Reusable CORS snippet for SIWX-OIDC endpoints.
+# Browsers reject comma-separated values on Access-Control-Allow-Origin, so we
+# echo the request Origin when it matches the allowlist below. Add new browser
+# clients (Cinny, Beeper, etc.) to BOTH matcher lines.
+(siwx_cors_allowlist) {
+    @cors_origin header Origin "https://element.inblock.io" "https://app.cinny.in"
+    @cors_preflight {
+        method OPTIONS
+        header Origin "https://element.inblock.io" "https://app.cinny.in"
+    }
+    header @cors_origin Access-Control-Allow-Origin "{http.request.header.Origin}"
+    header @cors_origin Vary "Origin"
+    header @cors_origin Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+    header @cors_origin Access-Control-Allow-Headers "Authorization, Content-Type, X-Requested-With"
+    header @cors_origin Access-Control-Allow-Credentials "true"
+    header @cors_origin Access-Control-Max-Age "600"
+    respond @cors_preflight 204
+}
+
 matrix.inblock.io {
     encode zstd gzip
 
@@ -97,15 +116,15 @@ matrix.inblock.io {
     }
 
     handle /_matrix/client/v3/login {
-        header Access-Control-Allow-Origin "https://element.inblock.io"
+        import siwx_cors_allowlist
         reverse_proxy siwx-oidc:8081
     }
     handle /_matrix/client/v3/logout {
-        header Access-Control-Allow-Origin "https://element.inblock.io"
+        import siwx_cors_allowlist
         reverse_proxy siwx-oidc:8081
     }
     handle /_matrix/client/v3/refresh {
-        header Access-Control-Allow-Origin "https://element.inblock.io"
+        import siwx_cors_allowlist
         reverse_proxy siwx-oidc:8081
     }
 
@@ -116,7 +135,7 @@ matrix.inblock.io {
 
 siwx-oidc.inblock.io {
     encode zstd gzip
-    header Access-Control-Allow-Origin "https://element.inblock.io"
+    import siwx_cors_allowlist
     reverse_proxy siwx-oidc:8081
 }
 


### PR DESCRIPTION
## Summary

- Replace four hardcoded `Access-Control-Allow-Origin "https://element.inblock.io"` headers in the appended Caddyfile block with a reusable snippet that allowlists multiple origins (currently `element.inblock.io` and `app.cinny.in`)
- Add the missing `Vary: Origin`, CORS preflight (`OPTIONS` 204), and `Allow-Credentials` directives that the previous block lacked
- DRY the four call sites via Caddy's `import` snippet syntax

## Why

Reported in MY_TASKS.md #10 — Cinny fails on `https://app.cinny.in/` with:

```
Failed to get authentication flow information.
Access to fetch at 'https://matrix.inblock.io/_matrix/client/v3/login' from origin
'https://app.cinny.in' has been blocked by CORS policy: The
'Access-Control-Allow-Origin' header has a value 'https://element.inblock.io'
that is not equal to the supplied origin.
```

Introduced by `47ee219 fix: restrict CORS to element.inblock.io, keep wildcard only on well-known`. Browsers reject comma-separated `Access-Control-Allow-Origin` values, so the static-string approach can only ever permit one client. The correct idiom is to match the request `Origin` against an allowlist and echo that exact value back.

## What changes

```diff
- header Access-Control-Allow-Origin "https://element.inblock.io"
+ import siwx_cors_allowlist
```

…plus a new snippet at the top of the appended block:

```caddy
(siwx_cors_allowlist) {
    @cors_origin header Origin "https://element.inblock.io" "https://app.cinny.in"
    @cors_preflight {
        method OPTIONS
        header Origin "https://element.inblock.io" "https://app.cinny.in"
    }
    header @cors_origin Access-Control-Allow-Origin "{http.request.header.Origin}"
    header @cors_origin Vary "Origin"
    header @cors_origin Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
    header @cors_origin Access-Control-Allow-Headers "Authorization, Content-Type, X-Requested-With"
    header @cors_origin Access-Control-Allow-Credentials "true"
    header @cors_origin Access-Control-Max-Age "600"
    respond @cors_preflight 204
}
```

Applied to the three MSC3861-intercepted Matrix paths (`/login`, `/logout`, `/refresh`) on `matrix.inblock.io` and to the entire `siwx-oidc.inblock.io` host. Future clients (Beeper, mobile WebViews, etc.) only need their origin added to the two matcher lines.

## Deployment caveat

`deploy.sh:83` short-circuits if `matrix.inblock.io` is already present in the Caddyfile, so re-running `./deploy.sh` against an existing server **will not update** the broken block. The operator must hand-edit `/home/portal/portal/Caddyfile` (or strip the old block) and then:

```
docker exec portal-caddy-1 caddy reload --config /etc/caddy/Caddyfile
```

A follow-up could add BEGIN/END marker comments around the appended block so the script can replace its own managed section deterministically.

## Test plan

- [ ] Apply the change to the Caddyfile on `agentic.inblock.io`, reload Caddy
- [ ] `curl -sI -H 'Origin: https://app.cinny.in' https://matrix.inblock.io/_matrix/client/v3/login` → expect `Access-Control-Allow-Origin: https://app.cinny.in` and `Vary: Origin`
- [ ] Same with `Origin: https://element.inblock.io` → expect the element origin echoed back
- [ ] Same with `Origin: https://evil.example.com` → expect no `Access-Control-Allow-Origin` header at all
- [ ] `curl -sI -X OPTIONS -H 'Origin: https://app.cinny.in' -H 'Access-Control-Request-Method: POST' https://matrix.inblock.io/_matrix/client/v3/login` → expect 204 + all three CORS response headers
- [ ] Open https://app.cinny.in/, point homeserver to https://matrix.inblock.io, complete the wallet sign-in flow end-to-end
- [ ] Verify Element at https://element.inblock.io still logs in normally (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)